### PR TITLE
Some minor fixes

### DIFF
--- a/SimplestLoadBalancer.csproj
+++ b/SimplestLoadBalancer.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
+    <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In section that adds group, renamed variable group to group_id, to av…oid conflicts, also switched to using generic names for key and value.

Removed option that parsing address of incoming packet and using it as backend server. Added option to specify address for admin socket to manage configuration, default 127.0.0.1 Fixed port number parsing bits operation has low order - parenthesis to get the correct port number. Some debug prints.